### PR TITLE
GPS is working properly

### DIFF
--- a/air/Info.plist
+++ b/air/Info.plist
@@ -26,6 +26,10 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string></string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/air/ViewController.swift
+++ b/air/ViewController.swift
@@ -43,6 +43,11 @@ class ViewController: UIViewController, ARSKViewDelegate, CLLocationManagerDeleg
         }
     }
     
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        for currentLocation in locations{
+            print("\(currentLocation.coordinate)")
+        }
+    }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         

--- a/air/ViewController.swift
+++ b/air/ViewController.swift
@@ -9,13 +9,26 @@
 import UIKit
 import SpriteKit
 import ARKit
+import CoreLocation
 
-class ViewController: UIViewController, ARSKViewDelegate {
+class ViewController: UIViewController, ARSKViewDelegate, CLLocationManagerDelegate {
     
     @IBOutlet var sceneView: ARSKView!
     
+    let locationManager = CLLocationManager()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        locationManager.delegate = self
+        
+        locationManager.requestAlwaysAuthorization()
+        
+        locationManager.startUpdatingLocation()
+        
+        locationManager.stopUpdatingHeading()
+        
+        locationManager.distanceFilter = 20
         
         // Set the view's delegate
         sceneView.delegate = self


### PR DESCRIPTION
@Reenakoudi @noelleDL @somcode
GPS will be triggered as soon as the app is loaded, then it calls the function localManager and it will print the latitude and longitude
```
17.07316 CLLocationCoordinate2D(latitude: 51.617096015300241, longitude: -0.014240266755236536)
17.07316 CLLocationCoordinate2D(latitude: 51.61708641802111, longitude: -0.014233142137540721)
17.07316 CLLocationCoordinate2D(latitude: 51.617128998089221, longitude: -0.014266921207322055)
17.07316 CLLocationCoordinate2D(latitude: 51.617124010856834, longitude: -0.014232806861413859)
17.07316 CLLocationCoordinate2D(latitude: 51.617127405527619, longitude: -0.014226436615003482)
17.07316 CLLocationCoordinate2D(latitude: 51.617120239000407, longitude: -0.014221994206322563)
```